### PR TITLE
fix: handle non-main-thread signal registration in srun mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-04-02
+
+### Fixed
+
+- Signal handler registration in srun mode now skips gracefully when not on the
+  main thread, preventing `ValueError` crashes in threaded Prefect deployments.
+
 ## [0.1.6] - 2026-04-02
 
 ### Added
@@ -151,7 +158,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 - Dependabot for GitHub Actions.
 
 [Unreleased]:
-  https://github.com/dexterity-systems/prefect-submitit/compare/v0.1.6...HEAD
+  https://github.com/dexterity-systems/prefect-submitit/compare/v0.1.7...HEAD
+[0.1.7]:
+  https://github.com/dexterity-systems/prefect-submitit/compare/v0.1.6...v0.1.7
 [0.1.6]:
   https://github.com/dexterity-systems/prefect-submitit/compare/v0.1.5...v0.1.6
 [0.1.5]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prefect-submitit"
-version = "0.1.6"
+version = "0.1.7"
 description = "A Prefect 3 TaskRunner that submits tasks to SLURM clusters via submitit"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/prefect_submitit/runner.py
+++ b/src/prefect_submitit/runner.py
@@ -198,9 +198,14 @@ class SlurmTaskRunner(TaskRunner):
 
             self._backend = SrunBackend(self)
 
-            # Register SIGTERM handler so cleanup runs on job cancellation
-            self._prev_sigterm = signal.getsignal(signal.SIGTERM)
-            signal.signal(signal.SIGTERM, self._sigterm_handler)
+            # Register SIGTERM handler so cleanup runs on job cancellation.
+            # Skip if not on the main thread (signal handlers can only be
+            # registered from the main thread).
+            try:
+                self._prev_sigterm = signal.getsignal(signal.SIGTERM)
+                signal.signal(signal.SIGTERM, self._sigterm_handler)
+            except ValueError:
+                pass  # Not on main thread
 
         return self
 
@@ -224,7 +229,10 @@ class SlurmTaskRunner(TaskRunner):
             self._backend = None
             # Restore previous SIGTERM handler
             if hasattr(self, "_prev_sigterm"):
-                signal.signal(signal.SIGTERM, self._prev_sigterm)
+                try:
+                    signal.signal(signal.SIGTERM, self._prev_sigterm)
+                except ValueError:
+                    pass  # Not on main thread
         self._executor = None
         super().__exit__(*args)
 


### PR DESCRIPTION
## Summary

Fix `ValueError` crash when `SlurmTaskRunner` is used in srun mode from a non-main thread (e.g., threaded Prefect deployments). Bumps version to 0.1.7.

## Changes

- Signal handler registration (`SIGTERM`) now catches `ValueError` and skips gracefully when not on the main thread, in both `__enter__` and `__exit__`
- Version bump to 0.1.7 with changelog entry

## Testing

- [x] Existing tests pass (`pixi run -e dev test` — 370 passed)
- [x] Linting passes (`pixi run -e dev fmt`)
- [x] No formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)