### PR TITLE
per-task slurm resource overrides using a new task import from prefec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Per-task SLURM resource overrides: import `task` from `prefect_submitit` (a
+  drop-in for Prefect's `@task`) and pass `slurm_kwargs` to override executor
+  parameters (e.g. `cpus_per_task`, `timeout_min`, `slurm_nodes`) for a single
+  task. Overrides apply to `.submit()` and `.map()` in `slurm` mode and are
+  restored afterwards; `srun` mode warns and ignores them, `local` mode ignores
+  them.
+
 ## [0.1.7] - 2026-04-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -143,6 +143,47 @@ export SLURM_TASKRUNNER_BACKEND=local
 Additional keyword arguments are passed through to submitit (e.g.
 `slurm_gres="gpu:a100:1"`).
 
+## Per-task resource overrides
+
+The `SlurmTaskRunner` parameters above set defaults for every task in the flow.
+To vary resources for individual tasks, import `task` from `prefect_submitit`
+instead of `prefect` — it is a drop-in replacement for Prefect's `@task` that
+also accepts a `slurm_kwargs` mapping:
+
+```python
+from prefect import flow
+from prefect_submitit import SlurmTaskRunner, task
+
+
+@task
+def light(x: int) -> int:
+    return x  # uses the runner default: cpus_per_task=1
+
+
+@task(slurm_kwargs={"cpus_per_task": 4})
+def heavy(x: int) -> int:
+    return x  # this task only is submitted with 4 CPUs
+
+
+@flow(task_runner=SlurmTaskRunner(partition="cpu", cpus_per_task=1))
+def my_flow():
+    light.submit(1)
+    heavy.submit(2)
+```
+
+The override applies to both `.submit()` and `.map()`, and the runner defaults
+are restored afterwards so other tasks are unaffected.
+
+> **`slurm_kwargs` uses submitit executor parameter names, not the
+> `SlurmTaskRunner` constructor names.** Some names match (`cpus_per_task`,
+> `mem_gb`, `gpus_per_node`); others differ — use `timeout_min=30` (not
+> `time_limit="00:30:00"`) and `slurm_partition="gpu"` (not `partition="gpu"`).
+> This matches the runner's pass-through `**slurm_kwargs` (e.g. `slurm_gres`).
+
+Per-task `slurm_kwargs` only take effect in `slurm` mode. In `srun` mode they
+are ignored with a warning (srun bypasses submitit); in `local` mode they are
+ignored.
+
 ## Examples
 
 The `examples/` directory contains Jupyter notebooks demonstrating each feature

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,7 @@ postgresql = ">=16"
 [tool.pixi.pypi-dependencies]
 prefect-submitit = { path = ".", editable = true }
 prefect = { version = ">=3.6,<4.0", extras = ["dask"] }
-submitit = "*"  # For SLURM job submission
 asyncpg = "*"  # PostgreSQL async driver for Prefect server
-cloudpickle = "*"  # For serializing Python objects
 
 # =============================================================================
 # DEV FEATURE - Development tools (testing, linting)

--- a/src/prefect_submitit/__init__.py
+++ b/src/prefect_submitit/__init__.py
@@ -11,6 +11,7 @@ from prefect_submitit.futures import (
     SrunPrefectFuture,
 )
 from prefect_submitit.runner import SlurmTaskRunner
+from prefect_submitit.task import task
 
 __all__ = [
     "ExecutionMode",
@@ -20,4 +21,5 @@ __all__ = [
     "SlurmPrefectFuture",
     "SlurmTaskRunner",
     "SrunPrefectFuture",
+    "task",
 ]

--- a/src/prefect_submitit/runner.py
+++ b/src/prefect_submitit/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import signal
+import threading
 import uuid
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Self
@@ -113,6 +114,8 @@ class SlurmTaskRunner(TaskRunner):
         self._backend: Any | None = None
         self._entered: bool = False
         self._cached_max_array_size: int | None = None
+        self._base_executor_params: dict[str, Any] = {}
+        self._submit_lock = threading.Lock()
 
     def _parse_time_to_minutes(self, time_str: str) -> int:
         return parse_time_to_minutes(time_str)
@@ -141,9 +144,11 @@ class SlurmTaskRunner(TaskRunner):
                 )
 
             self._executor = submitit.LocalExecutor(folder=self.log_folder)
-            self._executor.update_parameters(
-                timeout_min=self._parse_time_to_minutes(self.time_limit),
-            )
+            local_params: dict[str, Any] = {
+                "timeout_min": self._parse_time_to_minutes(self.time_limit),
+            }
+            self._executor.update_parameters(**local_params)
+            self._base_executor_params = local_params
         elif self.execution_mode == ExecutionMode.SLURM:
             self._executor = submitit.AutoExecutor(folder=f"{self.log_folder}/%j")
             params: dict[str, Any] = {
@@ -167,6 +172,7 @@ class SlurmTaskRunner(TaskRunner):
 
             params.update(self.slurm_kwargs)
             self._executor.update_parameters(**params)
+            self._base_executor_params = params
         elif self.execution_mode == ExecutionMode.SRUN:
             if not os.environ.get("SLURM_JOB_ID"):
                 msg = (
@@ -221,6 +227,18 @@ class SlurmTaskRunner(TaskRunner):
             self._prev_sigterm(signum, frame)
         else:
             raise SystemExit(128 + signum)
+
+    def __getstate__(self) -> dict[str, Any]:
+        # SlurmTaskRunner is serialized as part of the Prefect flow run context for
+        # every task submission. threading.Lock cannot be pickled, so exclude it.
+        state = self.__dict__.copy()
+        del state["_submit_lock"]
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Restore all state, then recreate the lock that was excluded in __getstate__.
+        self.__dict__.update(state)
+        self._submit_lock = threading.Lock()
 
     def __exit__(self, *args: Any) -> None:
         self._entered = False
@@ -302,7 +320,18 @@ class SlurmTaskRunner(TaskRunner):
         if self.execution_mode == ExecutionMode.SRUN:
             return self._backend.submit_one(wrapped_call, task_run_id)
 
-        job = self._executor.submit(wrapped_call)
+        task_slurm_kwargs = getattr(task.fn, "_slurm_kwargs", {})
+        # update_parameters mutates shared executor state, so this overriding
+		# of slurm_kwargs must be atomic across concurrent submissions.
+        with self._submit_lock:
+            if task_slurm_kwargs:
+                self._executor.update_parameters(
+                    **{**self._base_executor_params, **task_slurm_kwargs}
+                )
+            job = self._executor.submit(wrapped_call)
+            if task_slurm_kwargs:
+                # Restore to runner defaults.
+                self._executor.update_parameters(**self._base_executor_params)
 
         max_poll = self.max_poll_time
         if max_poll is None:

--- a/src/prefect_submitit/runner.py
+++ b/src/prefect_submitit/runner.py
@@ -322,16 +322,18 @@ class SlurmTaskRunner(TaskRunner):
 
         task_slurm_kwargs = getattr(task.fn, "_slurm_kwargs", {})
         # update_parameters mutates shared executor state, so this overriding
-		# of slurm_kwargs must be atomic across concurrent submissions.
+        # of slurm_kwargs must be atomic across concurrent submissions.
         with self._submit_lock:
             if task_slurm_kwargs:
                 self._executor.update_parameters(
                     **{**self._base_executor_params, **task_slurm_kwargs}
                 )
-            job = self._executor.submit(wrapped_call)
-            if task_slurm_kwargs:
-                # Restore to runner defaults.
-                self._executor.update_parameters(**self._base_executor_params)
+            try:
+                job = self._executor.submit(wrapped_call)
+            finally:
+                if task_slurm_kwargs:
+                    # Restore to runner defaults.
+                    self._executor.update_parameters(**self._base_executor_params)
 
         max_poll = self.max_poll_time
         if max_poll is None:

--- a/src/prefect_submitit/runner.py
+++ b/src/prefect_submitit/runner.py
@@ -318,6 +318,14 @@ class SlurmTaskRunner(TaskRunner):
         )
 
         if self.execution_mode == ExecutionMode.SRUN:
+            task_slurm_kwargs = getattr(task.fn, "_slurm_kwargs", {})
+            if task_slurm_kwargs:
+                logger.warning(
+                    "Task '%s' has slurm_kwargs %s, but the runner is in SRUN mode "
+                    "which bypasses submitit — per-task SLURM overrides are ignored.",
+                    task.name,
+                    task_slurm_kwargs,
+                )
             return self._backend.submit_one(wrapped_call, task_run_id)
 
         task_slurm_kwargs = getattr(task.fn, "_slurm_kwargs", {})
@@ -466,6 +474,14 @@ class SlurmTaskRunner(TaskRunner):
 
         # -- SRUN mode: dispatch via srun backend ----------------------------
         if self.execution_mode == ExecutionMode.SRUN:
+            task_slurm_kwargs = getattr(task.fn, "_slurm_kwargs", {})
+            if task_slurm_kwargs:
+                logger.warning(
+                    "Task '%s' has slurm_kwargs %s, but the runner is in SRUN mode "
+                    "which bypasses submitit — per-task SLURM overrides are ignored.",
+                    task.name,
+                    task_slurm_kwargs,
+                )
             return self._map_srun(
                 task, iterable_params, static_params, map_length, logger
             )

--- a/src/prefect_submitit/runner.py
+++ b/src/prefect_submitit/runner.py
@@ -471,45 +471,58 @@ class SlurmTaskRunner(TaskRunner):
             )
 
         # -- SLURM / LOCAL mode: dispatch via submitit -----------------------
-        if self.units_per_worker > 1:
-            if len(iterable_params) > 1:
-                msg = (
-                    "Multi-argument map() is not supported with units_per_worker > 1. "
-                    f"Found {len(iterable_params)} iterable parameters: "
-                    f"{list(iterable_params.keys())}. "
-                    "Use units_per_worker=1 for multi-arg map, or pre-zip arguments "
-                    "into single iterable."
+        task_slurm_kwargs = getattr(task.fn, "_slurm_kwargs", {})
+        # update_parameters mutates shared executor state, so this overriding of
+        # slurm_kwargs must be atomic across concurrent submissions (same as submit()).
+        with self._submit_lock:
+            if task_slurm_kwargs:
+                self._executor.update_parameters(
+                    **{**self._base_executor_params, **task_slurm_kwargs}
                 )
-                raise ValueError(msg)
-            param_name = next(iter(iterable_params.keys()))
-            items = iterable_params[param_name]
-            num_batches = (
-                len(items) + self.units_per_worker - 1
-            ) // self.units_per_worker
-            logger.info(
-                "Submitting %s items as %s batched SLURM jobs "
-                "(units_per_worker=%s, partition=%s, parallelism=%s)",
-                len(items),
-                num_batches,
-                self.units_per_worker,
-                self.partition,
-                self.slurm_array_parallelism,
-            )
-            batched_futures = self._submit_batched_job_array(
-                task, items, param_name, static_params
-            )
-            return PrefectFutureList(batched_futures)  # type: ignore[abstract]
+            try:
+                if self.units_per_worker > 1:
+                    if len(iterable_params) > 1:
+                        msg = (
+                            "Multi-argument map() is not supported with units_per_worker > 1. "
+                            f"Found {len(iterable_params)} iterable parameters: "
+                            f"{list(iterable_params.keys())}. "
+                            "Use units_per_worker=1 for multi-arg map, or pre-zip arguments "
+                            "into single iterable."
+                        )
+                        raise ValueError(msg)
+                    param_name = next(iter(iterable_params.keys()))
+                    items = iterable_params[param_name]
+                    num_batches = (
+                        len(items) + self.units_per_worker - 1
+                    ) // self.units_per_worker
+                    logger.info(
+                        "Submitting %s items as %s batched SLURM jobs "
+                        "(units_per_worker=%s, partition=%s, parallelism=%s)",
+                        len(items),
+                        num_batches,
+                        self.units_per_worker,
+                        self.partition,
+                        self.slurm_array_parallelism,
+                    )
+                    futures: list[Any] = self._submit_batched_job_array(
+                        task, items, param_name, static_params
+                    )
+                else:
+                    logger.info(
+                        "Submitting %s tasks as SLURM job array (partition=%s, parallelism=%s)",
+                        map_length,
+                        self.partition,
+                        self.slurm_array_parallelism,
+                    )
+                    futures = self._submit_job_array(
+                        task, iterable_params, static_params, map_length
+                    )
+            finally:
+                if task_slurm_kwargs:
+                    # Restore to runner defaults.
+                    self._executor.update_parameters(**self._base_executor_params)
 
-        logger.info(
-            "Submitting %s tasks as SLURM job array (partition=%s, parallelism=%s)",
-            map_length,
-            self.partition,
-            self.slurm_array_parallelism,
-        )
-        array_futures = self._submit_job_array(
-            task, iterable_params, static_params, map_length
-        )
-        return PrefectFutureList(array_futures)  # type: ignore[abstract]
+        return PrefectFutureList(futures)  # type: ignore[abstract]
 
     def _map_srun(
         self,

--- a/src/prefect_submitit/task.py
+++ b/src/prefect_submitit/task.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Any
+from prefect import task as prefect_task
+
+
+def task(
+    *args: Any,
+    slurm_kwargs: dict[str, Any] | None = None,
+    **prefect_kwargs: Any,
+) -> Any:
+    """Task decorator that attaches per-task SLURM resource overrides.
+
+    SLURM parameters specified here override the SlurmTaskRunner defaults for
+    this task only. All other Prefect task options are forwarded to @task.
+
+    Args:
+        slurm_kwargs: SLURM parameters to override.
+            These are submitit executor parameters, not SlurmTaskRunner parameters
+            (e.g. use timeout_min=1, not time_limit="00:01:00").
+        **prefect_kwargs: Forwarded to Prefect's @task decorator.
+
+    Example:
+        @task(slurm_kwargs={"slurm_nodes": 2, "slurm_ntasks_per_node": 4})
+        def my_task(x: int) -> int:
+            ...
+    """
+
+    def decorator(fn: Any) -> Any:
+        fn._slurm_kwargs = slurm_kwargs or {}
+        return prefect_task(fn, **prefect_kwargs)
+
+    if args:
+        # Called as @task without parentheses
+        return decorator(args[0])
+    return decorator

--- a/src/prefect_submitit/task.py
+++ b/src/prefect_submitit/task.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 from typing import Any
+
 from prefect import task as prefect_task
 
 

--- a/tests/integration/tasks.py
+++ b/tests/integration/tasks.py
@@ -98,3 +98,11 @@ def return_unpicklable():
         yield 1
 
     return gen()
+
+
+@task
+def get_slurm_cpus_per_task() -> str | None:
+    """Return SLURM_CPUS_PER_TASK from the job environment."""
+    import os
+
+    return os.environ.get("SLURM_CPUS_PER_TASK")

--- a/tests/integration/test_slurm_kwargs.py
+++ b/tests/integration/test_slurm_kwargs.py
@@ -1,0 +1,113 @@
+"""Integration tests verifying per-task slurm_kwargs overrides are applied on SLURM."""
+
+from __future__ import annotations
+
+import pytest
+from prefect import flow
+
+from prefect_submitit.task import task as slurm_task
+from tests.integration.tasks import get_slurm_cpus_per_task
+
+pytestmark = pytest.mark.slurm
+
+
+@slurm_task(slurm_kwargs={"cpus_per_task": 2})
+def get_cpus_with_override(x: int = 0) -> str | None:  # noqa: ARG001
+    """Report SLURM_CPUS_PER_TASK; submitted with cpus_per_task=2 override.
+
+    Args:
+        x: Ignored; exists so this task can be used with .map().
+    """
+    import os
+
+    return os.environ.get("SLURM_CPUS_PER_TASK")
+
+
+class TestSubmitSlurmKwargsOverride:
+    """Verify that per-task slurm_kwargs are applied for submit()."""
+
+    def test_cpus_override_applied(self, make_slurm_runner, slurm_jobs):
+        """Task with cpus_per_task=2 override sees SLURM_CPUS_PER_TASK=2."""
+        # Runner default is 1 CPU; task override requests 2.
+        runner = make_slurm_runner(cpus_per_task=1)
+
+        @flow(task_runner=runner)
+        def compute():
+            future = get_cpus_with_override.submit()
+            slurm_jobs.append(future.slurm_job_id)
+            return future.result()
+
+        result = compute()
+        assert result == "2", f"Expected SLURM_CPUS_PER_TASK=2, got {result!r}"
+
+    def test_override_does_not_affect_subsequent_task(
+        self, make_slurm_runner, slurm_jobs
+    ):
+        """Runner defaults are restored after a per-task override."""
+        runner = make_slurm_runner(cpus_per_task=1)
+
+        @flow(task_runner=runner)
+        def compute():
+            # Submit overriding task first, then a plain task.
+            future_override = get_cpus_with_override.submit()
+            slurm_jobs.append(future_override.slurm_job_id)
+
+            future_plain = get_slurm_cpus_per_task.submit()
+            slurm_jobs.append(future_plain.slurm_job_id)
+
+            return future_override.result(), future_plain.result()
+
+        cpus_override, cpus_plain = compute()
+        assert cpus_override == "2", f"Expected override=2, got {cpus_override!r}"
+        # Plain task should inherit the runner default (1 CPU).
+        assert cpus_plain == "1", f"Expected plain=1, got {cpus_plain!r}"
+
+
+class TestMapSlurmKwargsOverride:
+    """Verify that per-task slurm_kwargs are applied for map()."""
+
+    def test_cpus_override_applied_in_map(self, make_slurm_runner, slurm_jobs):
+        """All array tasks see the overridden SLURM_CPUS_PER_TASK."""
+        runner = make_slurm_runner(cpus_per_task=1)
+
+        @flow(task_runner=runner)
+        def compute():
+            # get_cpus_with_override has cpus_per_task=2 override; x is ignored
+            futures = get_cpus_with_override.map(x=[1, 2, 3])
+            for f in futures:
+                slurm_jobs.append(f.slurm_job_id)
+            return [f.result() for f in futures]
+
+        results = compute()
+        assert all(r == "2" for r in results), (
+            f"Expected all SLURM_CPUS_PER_TASK=2, got {results!r}"
+        )
+
+    def test_override_does_not_affect_subsequent_map(
+        self, make_slurm_runner, slurm_jobs
+    ):
+        """Runner defaults are restored after a per-task override map."""
+        runner = make_slurm_runner(cpus_per_task=1)
+
+        @flow(task_runner=runner)
+        def compute():
+            futures_override = get_cpus_with_override.map(x=[1, 2])
+            for f in futures_override:
+                slurm_jobs.append(f.slurm_job_id)
+
+            f1 = get_slurm_cpus_per_task.submit()
+            f2 = get_slurm_cpus_per_task.submit()
+            slurm_jobs.append(f1.slurm_job_id)
+            slurm_jobs.append(f2.slurm_job_id)
+
+            override_results = [f.result() for f in futures_override]
+            plain_results = [f1.result(), f2.result()]
+            return override_results, plain_results
+
+        cpus_override, cpus_plain = compute()
+        assert all(r == "2" for r in cpus_override), (
+            f"Expected override=2, got {cpus_override!r}"
+        )
+        assert all(r == "1" for r in cpus_plain), (
+            f"Expected plain=1, got {cpus_plain!r}"
+        )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -278,6 +278,54 @@ class TestSlurmTaskRunnerSubmit:
         assert future.slurm_job_id == "12345"
         assert isinstance(future.task_run_id, UUID)
 
+    @patch("prefect.context.serialize_context")
+    @patch("prefect.settings.context.get_current_settings")
+    @patch("prefect.utilities.engine.resolve_inputs_sync")
+    @patch("prefect_submitit.runner.submitit.AutoExecutor")
+    def test_per_task_slurm_kwargs_applied_and_restored(
+        self,
+        mock_executor_class,
+        mock_resolve_inputs,
+        mock_settings,
+        mock_serialize_context,
+    ):
+        mock_job = MagicMock()
+        mock_job.job_id = "12345"
+        mock_executor = MagicMock()
+        mock_executor.submit.return_value = mock_job
+        mock_executor_class.return_value = mock_executor
+
+        mock_resolve_inputs.return_value = {"x": 5}
+        mock_settings.return_value.to_environment_variables.return_value = {}
+        mock_serialize_context.return_value = {}
+
+        def task_fn(x: int) -> int:
+            return x * 2
+
+        task_fn._slurm_kwargs = {"cpus_per_task": 4}
+
+        mock_task = MagicMock()
+        mock_task.fn = task_fn
+        mock_task.name = "test_task"
+        mock_task.isasync = False
+
+        runner = SlurmTaskRunner(cpus_per_task=1)
+
+        with runner:
+            runner.submit(mock_task, {"x": 5})
+
+        update_calls = mock_executor.update_parameters.call_args_list
+        # First call is SlurmTaskRunner.__enter__ (base params)
+        # Second call overrides for task
+        # Third call restores base params
+        assert len(update_calls) == 3
+        original_kwargs = update_calls[0][1]
+        override_kwargs = update_calls[1][1]
+        restore_kwargs = update_calls[2][1]
+        assert original_kwargs["cpus_per_task"] == 1
+        assert override_kwargs["cpus_per_task"] == 4
+        assert restore_kwargs["cpus_per_task"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Map
@@ -357,6 +405,51 @@ class TestSlurmTaskRunnerMap:
         assert len(futures) == 3
         assert isinstance(futures, PrefectFutureList)
         assert all(isinstance(f, SlurmArrayPrefectFuture) for f in futures)
+
+    @patch("prefect.utilities.engine.resolve_inputs_sync")
+    @patch("prefect.context.serialize_context")
+    @patch("prefect.settings.context.get_current_settings")
+    @patch("prefect_submitit.runner.submitit.AutoExecutor")
+    def test_per_task_slurm_kwargs_applied_and_restored(
+        self, mock_executor_class, mock_settings, mock_serialize, mock_resolve
+    ):
+        mock_job = MagicMock()
+        mock_job.job_id = "12345_0"
+        mock_executor = MagicMock()
+        mock_executor.submit.return_value = mock_job
+        mock_executor_class.return_value = mock_executor
+
+        mock_settings.return_value.to_environment_variables.return_value = {}
+        mock_serialize.return_value = {}
+        mock_resolve.side_effect = lambda x, **kwargs: x
+
+        def task_fn(x: int) -> int:
+            return x * 2
+
+        task_fn._slurm_kwargs = {"cpus_per_task": 4}
+
+        mock_task = MagicMock()
+        mock_task.name = "test_task"
+        mock_task.fn = task_fn
+        mock_task.isasync = False
+
+        runner = SlurmTaskRunner(cpus_per_task=1, max_array_size=1000)
+
+        with runner:
+            futures = runner.map(mock_task, {"x": [1, 2, 3]})
+
+        assert len(futures) == 3
+        update_calls = mock_executor.update_parameters.call_args_list
+        # First call is SlurmTaskRunner.__enter__ (base params)
+        # Second call overrides for task
+        # Third call restores base params
+        assert len(update_calls) == 3
+        original_kwargs = update_calls[0][1]
+        override_kwargs = update_calls[1][1]
+        restore_kwargs = update_calls[2][1]
+        assert original_kwargs["cpus_per_task"] == 1
+        assert override_kwargs["cpus_per_task"] == 4
+        assert restore_kwargs["cpus_per_task"] == 1
 
 
 class TestJobArrayChunking:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -948,3 +948,91 @@ class TestSrunBackend:
 
         mock_backend.submit_many.assert_called_once()
         assert len(futures) == 3
+
+    @patch("prefect.utilities.engine.resolve_inputs_sync")
+    @patch("prefect.context.serialize_context")
+    @patch("prefect.settings.context.get_current_settings")
+    @patch("prefect_submitit.srun.SrunBackend")
+    def test_submit_warns_on_slurm_kwargs_in_srun(
+        self,
+        mock_backend_class,
+        mock_settings,
+        mock_serialize,
+        mock_resolve,
+        monkeypatch,
+        caplog,
+    ):
+        monkeypatch.setenv("SLURM_JOB_ID", "999")
+        mock_backend = MagicMock()
+        mock_backend_class.return_value = mock_backend
+
+        mock_serialize.return_value = {}
+        mock_settings.return_value.to_environment_variables.return_value = {}
+        mock_resolve.side_effect = lambda x, **kwargs: x
+
+        def task_fn(x: int) -> int:
+            return x
+
+        task_fn._slurm_kwargs = {"cpus_per_task": 4}
+
+        runner = SlurmTaskRunner(execution_mode="srun")
+        mock_task = MagicMock()
+        mock_task.name = "heavy_task"
+        mock_task.fn = task_fn
+
+        with (
+            caplog.at_level(logging.WARNING, logger="prefect.task_runner.slurm"),
+            runner,
+        ):
+            runner.submit(mock_task, {"x": 1})
+
+        assert "slurm_kwargs" in caplog.text
+        assert "SRUN mode" in caplog.text
+        assert "heavy_task" in caplog.text
+        # The override is still ignored: the backend is invoked normally.
+        mock_backend.submit_one.assert_called_once()
+
+    @patch("prefect.utilities.engine.resolve_inputs_sync")
+    @patch("prefect.context.serialize_context")
+    @patch("prefect.settings.context.get_current_settings")
+    @patch("prefect_submitit.srun.SrunBackend")
+    def test_map_warns_on_slurm_kwargs_in_srun(
+        self,
+        mock_backend_class,
+        mock_settings,
+        mock_serialize,
+        mock_resolve,
+        monkeypatch,
+        caplog,
+    ):
+        monkeypatch.setenv("SLURM_JOB_ID", "999")
+        mock_backend = MagicMock()
+        mock_backend.submit_many.return_value = [MagicMock(), MagicMock(), MagicMock()]
+        mock_backend_class.return_value = mock_backend
+
+        mock_serialize.return_value = {}
+        mock_settings.return_value.to_environment_variables.return_value = {}
+        mock_resolve.side_effect = lambda x, **kwargs: x
+
+        def task_fn(x: int) -> int:
+            return x
+
+        task_fn._slurm_kwargs = {"cpus_per_task": 4}
+
+        runner = SlurmTaskRunner(execution_mode="srun")
+        mock_task = MagicMock()
+        mock_task.name = "heavy_task"
+        mock_task.fn = task_fn
+        mock_task.isasync = False
+
+        with (
+            caplog.at_level(logging.WARNING, logger="prefect.task_runner.slurm"),
+            runner,
+        ):
+            futures = runner.map(mock_task, {"x": [1, 2, 3]})
+
+        assert "slurm_kwargs" in caplog.text
+        assert "SRUN mode" in caplog.text
+        assert "heavy_task" in caplog.text
+        mock_backend.submit_many.assert_called_once()
+        assert len(futures) == 3


### PR DESCRIPTION
@andrewcolinhunt - there's a proposed enhancement to `prefect-submitit` which will make it a very attractive candidate to ship along with our [quacc](https://quantum-accelerators.github.io/quacc/user/wflow_engine/executors.html#__tabbed_1_3) atomic simulation package - the capability of modifying task-level resources through a new `@task` decorator.

This is essentially the bare minimum functionality that I'm proposing here, but other suggestions are welcome of course.          

The core issue is that `submitit` supports per-submission parameter overrides via `update_parameters()` (see [here](https://github.com/facebookincubator/submitit/blob/main/docs/structure.md)), but `SlurmTaskRunner` only calls this once at flow startup, making it impossible to vary resources (CPUs, memory, nodes, etc.) per task.
                                                                                                                                                                       
## Changes                                                                     
                                                                                                                                   
  - Introduced `prefect_submitit.task`, a drop-in replacement for Prefect `@task` that accepts a `slurm_kwargs` argument. These kwargs are stored on the task function and applied per-submission to the `submitit` executor.  Users can continue to use `prefect.task` if they don't wish to modify any task-level resources.
                                                                                                                                                            
  Modified: src/prefect_submitit/runner.py                                                                                                                             
  - `__enter__` now saves the constructed executor parameter dict as `_base_executor_params`.                                            
  - `submit()` reads `_slurm_kwargs` for a task function and temporarily merges them over the base params before calling `executor.submit()`, then restores the base params.                                       
                                                                                                                                                                       

A typical usage for this functionality would be:
```                                                                                                                                                               
  from prefect import flow  
  from prefect_submitit import SlurmTaskRunner, task
  
  @task
  def default_task(x: int, y: int) -> int:
      ...  # gets cpus_per_task=1 from the runner
                                                                                         
  @task(slurm_kwargs={"cpus_per_task": 4})
  def cpu_heavy(x: int, y: int) -> int:
      ...  # overrides to 4 CPUs for this task only
      
  @flow(task_runner=SlurmTaskRunner(partition="debug", time_limit="00:10:00", cpus_per_task=1))
  def my_flow(x, y):
      default_task.submit(x, y)
      cpu_heavy.submit(x, y)                           
        
```

_Note: slurm_kwargs are submitit executor parameters (e.g. cpus_per_task, timeout_min, slurm_nodes), not SlurmTaskRunner parameters._ 
  
## Checklist

- [x] Code follows the project's style guidelines (`pixi run -e dev fmt`)
- [x] Tests pass locally (`pixi run -e dev test`)
- [ ] New/changed behavior is covered by tests
- [ ] CHANGELOG.md updated (if user-facing change)
- [x] Self-reviewed the diff

I can add tests and documentation if you think the changes would be of general interest to the community (they are definitely essential for our use-case!). Thanks!