### PR TITLE
chore: release 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-06-24
+
 ### Added
 
 - Per-task SLURM resource overrides: import `task` from `prefect_submitit` (a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prefect-submitit"
-version = "0.1.7"
+version = "0.1.8"
 description = "A Prefect 3 TaskRunner that submits tasks to SLURM clusters via submitit"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Bumps `pyproject.toml` to 0.1.8 and stamps the CHANGELOG (`[Unreleased]` → `[0.1.8] - 2026-06-24`).

The `v0.1.8` tag was cut before the version bump, so the release workflow built `0.1.7` artifacts and PyPI rejected them (file already exists). With this merged, the `v0.1.8` tag/release will be recreated on a commit whose `pyproject.toml` says 0.1.8, and the publish workflow will upload 0.1.8.

Verified locally: `python -m build` now produces `prefect_submitit-0.1.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)